### PR TITLE
New icon buttons, hidden when no row selected

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { DynamicTable } from './DynamicTable';
+import { Check, AttachFile, FileCopy } from '@mui/icons-material';
 
 const columns = [
     { field: 'id', headerName: 'ID' },
@@ -28,14 +29,20 @@ const options = {
 const tools = [
     {
         name: 'Approve',
+        icon: <Check />,
+        tooltip: 'Approve selected rows',
         action: (selectedRows) => alert(`Approved ${selectedRows.map(row => row.name).join(', ')}`),
     },
     {
         name: 'View Attachments',
+        icon: <AttachFile />,
+        tooltip: 'View attachments for selected rows',
         action: (selectedRows) => alert(`Viewing attachments for ${selectedRows.map(row => row.name).join(', ')}`),
     },
     {
         name: 'Copy',
+        icon: <FileCopy />,
+        tooltip: 'Copy selected rows',
         action: (selectedRows) => alert(`Copied ${selectedRows.map(row => row.name).join(', ')}`),
     },
 ];

--- a/src/DynamicTable.jsx
+++ b/src/DynamicTable.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import {
     Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, TableSortLabel,
-    TablePagination, Checkbox, Button, Toolbar, Typography
+    TablePagination, Checkbox, IconButton, Toolbar, Typography, Tooltip
 } from '@mui/material';
 
 export const DynamicTable = ({ columns, data, options, tools }) => {
@@ -66,14 +66,12 @@ export const DynamicTable = ({ columns, data, options, tools }) => {
                 <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
                     Selected Rows: {selected.length}
                 </Typography>
-                {tools.map((tool, toolIndex) => (
-                    <Button
-                        key={toolIndex}
-                        onClick={() => tool.action(selected)}
-                        disabled={selected.length === 0}
-                    >
-                        {tool.name}
-                    </Button>
+                {selected.length > 0 && tools.map((tool, toolIndex) => (
+                    <Tooltip title={tool.tooltip} key={toolIndex}>
+                        <IconButton onClick={() => tool.action(selected)}>
+                            {tool.icon}
+                        </IconButton>
+                    </Tooltip>
                 ))}
             </Toolbar>
             <TableContainer component={Paper}>


### PR DESCRIPTION
## Spanish
### Explicación de los cambios:
**Iconos y Tooltips:** Los botones de herramientas ahora usan IconButton y Tooltip de Material-UI. Los iconos y los tooltips se pasan desde App.jsx.
**Mostrar/Ocultar herramientas:** Los botones de herramientas solo se muestran en la Toolbar si hay filas seleccionadas (selected.length > 0).

## English
### Explanation of changes:
**Icons and Tooltips:** Tool buttons now use Material-UI's IconButton and Tooltip. Icons and tooltips are passed from App.jsx.
**Show/Hide Tools:** Tool buttons are only shown in the Toolbar if there are selected rows (selected.length > 0).