### PR TITLE
Select for toggle columns

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,6 +1,6 @@
 import { DynamicTable } from './DynamicTable';
 import { Check, AttachFile, FileCopy } from '@mui/icons-material';
-import { approve, viewAttachments, copy } from '../actions';
+import { approve, viewAttachments, copy } from '../actions/';
 
 const columns = [
     { field: 'id', headerName: 'ID' },
@@ -25,6 +25,7 @@ const options = {
     sortable: true,
     pagination: true,
     toggleColumnVisibility: true,
+    userCanToggleColumns: true, // Permite al usuario ocultar/mostrar columnas
 };
 
 const tools = [

--- a/src/components/DynamicTable.jsx
+++ b/src/components/DynamicTable.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import {
     Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, TableSortLabel,
-    TablePagination, Checkbox, IconButton, Toolbar, Typography, Tooltip
+    TablePagination, Checkbox, IconButton, Toolbar, Typography, Tooltip, MenuItem, Select
 } from '@mui/material';
 
 export const DynamicTable = ({ columns, data, options, tools }) => {
@@ -73,6 +73,24 @@ export const DynamicTable = ({ columns, data, options, tools }) => {
                         </IconButton>
                     </Tooltip>
                 ))}
+                {options?.userCanToggleColumns && (
+                    <Select
+                        value=""
+                        displayEmpty
+                        onChange={(event) => handleToggleColumn(event.target.value)}
+                        renderValue={() => 'Toggle Columns'}
+                        style={{ marginLeft: 'auto' }}
+                    >
+                        {columns.map((column) => (
+                            <MenuItem key={column.field} value={column.field}>
+                                <Checkbox
+                                    checked={!hiddenColumns.includes(column.field)}
+                                />
+                                {column.headerName}
+                            </MenuItem>
+                        ))}
+                    </Select>
+                )}
             </Toolbar>
             <TableContainer component={Paper}>
                 <Table>
@@ -107,12 +125,6 @@ export const DynamicTable = ({ columns, data, options, tools }) => {
                                             </TableSortLabel>
                                         )}
                                         {!options?.sortable && column.headerName}
-                                        {options?.toggleColumnVisibility && (
-                                            <Checkbox
-                                                checked={!hiddenColumns.includes(column.field)}
-                                                onChange={() => handleToggleColumn(column.field)}
-                                            />
-                                        )}
                                     </TableCell>
                                 )
                             ))}


### PR DESCRIPTION
## Spanish

### Explicación de los cambios:
**userCanToggleColumns:** Añadimos una opción userCanToggleColumns en las opciones para permitir al usuario ocultar/mostrar columnas.
**Select para columnas:** Añadimos un Select en la barra de herramientas que muestra todas las columnas con una casilla de verificación para permitir al usuario ocultar/mostrar columnas.
**Rehabilitar columnas ocultas:** La lista desplegable de Select permite volver a mostrar las columnas ocultas.

Con estos cambios, los usuarios pueden ocultar y volver a mostrar columnas según la configuración especificada en las opciones.


## English

### Explanation of changes:
**userCanToggleColumns:** We added a userCanToggleColumns option in the options to allow the user to hide/show columns.
**Select for columns:** We added a Select in the toolbar that shows all columns with a checkbox to allow the user to hide/show columns.
**Re-enable hidden columns:** The Select dropdown allows hidden columns to be shown again.

With these changes, users can hide and show columns based on the settings specified in the options.